### PR TITLE
Use str#find in NamedParameter's match statement

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -232,7 +232,7 @@ impl<T> Node<T> {
                     None
                 }
             }
-            NodeKind::Parameter => match position(p, '/') {
+            NodeKind::Parameter => match p.find('/') {
                 Some(i) => {
                     let indices = self.indices.as_ref()?;
 

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -508,3 +508,39 @@ fn test_readme_example() {
     assert_eq!(*res.0, 12);
     assert_eq!(res.1, []);
 }
+
+#[test]
+fn test_named_routes_with_non_ascii_paths() {
+    let mut tree = PathTree::<usize>::new();
+    tree.insert("/", 0);
+    tree.insert("/*any", 1);
+    tree.insert("/matchme/:slug/", 2);
+
+    // ASCII only (single-byte characters)
+    let node = tree.find("/matchme/abc-s-def/");
+    assert_eq!(node.is_some(), true);
+    let res = node.unwrap();
+    assert_eq!(*res.0, 2);
+    assert_eq!(res.1, [("slug", "abc-s-def")]);
+
+    // with multibyte character
+    let node = tree.find("/matchme/abc-ß-def/");
+    assert_eq!(node.is_some(), true);
+    let res = node.unwrap();
+    assert_eq!(*res.0, 2);
+    assert_eq!(res.1, [("slug", "abc-ß-def")]);
+
+    // with emoji (fancy multibyte character)
+    let node = tree.find("/matchme/abc-⭐-def/");
+    assert_eq!(node.is_some(), true);
+    let res = node.unwrap();
+    assert_eq!(*res.0, 2);
+    assert_eq!(res.1, [("slug", "abc-⭐-def")]);
+
+    // with multibyte character right before the slash (char boundary check)
+    let node = tree.find("/matchme/abc-def-ß/");
+    assert_eq!(node.is_some(), true);
+    let res = node.unwrap();
+    assert_eq!(*res.0, 2);
+    assert_eq!(res.1, [("slug", "abc-def-ß")]);
+}


### PR DESCRIPTION
Hi @fundon,

Thank you for creating and maintaining this tiny but awesome library! 💙 

I stumbled upon an issue and also found a suitable solution, provided with this PR.

(in [impl Node\<T> find])

https://github.com/viz-rs/path-tree/blob/4090e8da241c9a8eefda87f650fda555447de89d/src/lib.rs#L235-L245

**tl;dr**: not every char is represented with a single byte.

For the match value in NodeKind::Parameter we need to determine the byte index, **not** the char index, otherwise we will be off for multibyte characters in the slice further down (since such slices are basically byte slices). In worst case scenarios this could lead to panics due to the index not being on a char boundary for the slice.

The find methodon the other hand respects that and returns exactly what we will need for the slicing.

### Example

```rust
// .chars().position(...) vs .find(...)

fn main() {
    let p1 = "sx/";
    let p2 = "ßx/";
    let p3 = "xß/";

    check(p1);
    check(p2);
    check(p3);
}

fn check(p: &str) {
    println!(
      "p: {:?} | {:?} | byte len: {}, char count: {}",
      p, p.as_bytes(), p.len(), p.chars().count());

    let i = p.find('/').unwrap();
    println!("find / => {:?}", i);
    println!("p[i..] => {:?}", &p[i..]);

    let i = p.chars().position(|x| x == '/').unwrap();
    println!("c.p? / => {:?}", i);
    if p.is_char_boundary(i) {
        println!("p[i..] => {:?}", &p[i..]);
    } else {
        println!("p[i..] => would panic (not at char boundary)!");
    }
}
```

```text
# output

p: "sx/" | [115, 120, 47] | byte len: 3, char count: 3
find / => 2
p[i..] => "/"
c.p? / => 2
p[i..] => "/"
p: "ßx/" | [195, 159, 120, 47] | byte len: 4, char count: 3
find / => 3
p[i..] => "/"
c.p? / => 2
p[i..] => "x/"
p: "xß/" | [120, 195, 159, 47] | byte len: 4, char count: 3
find / => 3
p[i..] => "/"
c.p? / => 2
p[i..] => would panic (not at char boundary)!
```

### References

* <https://doc.rust-lang.org/std/primitive.str.html#method.find>


### Notes

There are more `&p[l..]` slices, but they depend on the result of the `.len()` method, which does return the length in bytes and not chars, so such places are safe.
And the other match statements, where the `position` function is used are also fine, as they need the char based indices for the node lookup and would actually break on byte indices for multibyte strings in the router/tree side; when I tried to fix the issue just in the position function some other tests would have failed with panics or mismatches.

_Sorry for the long text for such a tiny fix, but it took me a while to narrow down where the problem was, and this PR description should act as a write down of my thinking process._