### PR TITLE
Some breaking and no so safe optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 
 - **Fast**: See benchmark
 
-- **Micro**: The [src/lib.rs](src/lib.rs) file is ~407 lines of code (Includes comments)
+- **Micro**: The [src/lib.rs](src/lib.rs) file is ~401 lines of code (Includes comments)
 
 - **Flexible**:
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 
 - **Fast**: See benchmark
 
-- **Micro**: The [src/lib.rs](src/lib.rs) file is ~396 lines of code (Includes comments)
+- **Micro**: The [src/lib.rs](src/lib.rs) file is ~407 lines of code (Includes comments)
 
 - **Flexible**:
 


### PR DESCRIPTION
Hey, I'm back again, for some reason I keep coming back trying to find optimizations.

This time I found two:

1. Replace the `Node.indices` `String` with a `Vec<char>`, this avoids the expensive code point decoding in `position`.
2. This is an `unsafe` one (and also a breaking change), I managed to remove the allocation when merging the `Node.params` and path `params` by using `Vec::from_raw_parts`.

These combined make it on par with matchit when I ran the benchmark (give or take 2us).

Feel free to close this and take the first optimization if you want, just wanted to report my findings.

Edit: Another braking change optimization that I didn't include was making `Node`s reference the original inserted path (`&'a str`). This speed up the `insert` benchmark to be as fast as `find`ing, but it made both `PathTree` and `Node` require a lifetime which would hinder usability.