### PR TITLE
feat: handle empty paths

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,7 +193,7 @@ impl<T> Node<T> {
             NodeKind::Static(ref s) => {
                 let l = loc(s, p);
 
-                if l == 0 || l < s.len() {
+                if l < s.len() {
                     None
                 } else if l == s.len() && l == p.len() {
                     Some(
@@ -297,7 +297,7 @@ impl<T> PathTree<T> {
     #[inline]
     pub fn new() -> Self {
         Self {
-            root: Node::new(NodeKind::Static("/".to_owned())),
+            root: Node::new(NodeKind::Static("".to_owned())),
             params: 0,
         }
     }
@@ -309,8 +309,6 @@ impl<T> PathTree<T> {
         let mut params: Option<Vec<String>> = None;
 
         let mut most = 0;
-
-        path = path.trim_start_matches('/');
 
         if path.is_empty() {
             node.data.replace(data);

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -5,7 +5,8 @@ use rand::seq::SliceRandom;
 fn new_tree() {
     let mut tree: PathTree<usize> = PathTree::default();
 
-    const ROUTES: [&str; 13] = [
+    const ROUTES: [&str; 14] = [
+        "",
         "/",
         "/users",
         "/users/:id",
@@ -21,7 +22,8 @@ fn new_tree() {
         "/users/repos/*any",
     ];
 
-    const VALID_URLS: [&str; 13] = [
+    const VALID_URLS: [&str; 14] = [
+        "",
         "/",
         "/users",
         "/users/fundon",
@@ -38,6 +40,7 @@ fn new_tree() {
     ];
 
     let valid_res = vec![
+        vec![],
         vec![],
         vec![],
         vec![("id", "fundon")],


### PR DESCRIPTION
I needed this so that I can compose routers, something like:

```python
Router(
  {
    "/users": Router(
      {
        "": users_endpoint,
        "/:name": user_endpoint,
       }
    )
)
```

Basically the "value" can be an endpoint or another router, but currently the router assumes/forces the path to start with `"/"` which in this example means it's impossible to match "/users".