### PR TITLE
Remove lifetime

### DIFF
--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -76,7 +76,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // │   ├── rust •3
     // │   └── ** •1
     // └── POST/login •4
-    let mut tree = PathTree::<'static, Box<dyn Handler>>::new();
+    let mut tree = PathTree::<Box<dyn Handler>>::new();
     tree.insert("/GET/", Box::new(index));
     tree.insert("/GET/*", Box::new(hello_world));
     tree.insert("/GET/hello/:name", Box::new(hello_user));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,7 +167,7 @@ impl<T> PathTree<T> {
         }
     }
 
-    pub fn insert(&mut self, path: &'a str, value: T) -> usize {
+    pub fn insert(&mut self, path: &str, value: T) -> usize {
         if path.is_empty() {
             return self.id;
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,7 +175,7 @@ impl<T> PathTree<T> {
         let mut node = &mut self.node;
         let pieces = Parser::new(path).collect::<Vec<_>>();
 
-        for piece in pieces.iter() {
+        for piece in &pieces {
             match piece {
                 Piece::String(s) => {
                     node = node.insert_bytes(&s[..]);
@@ -192,7 +192,7 @@ impl<T> PathTree<T> {
         self
     }
 
-    pub fn find<'a, 'b>(&'a self, path: &'b str) -> Option<Path<'a, 'b, T>> {
+    pub fn find<'b>(&self, path: &'b str) -> Option<Path<'_, 'b, T>> {
         let bytes = path.as_bytes();
         self.node.find(bytes).and_then(|(id, ranges)| {
             self.get_route(*id).map(|(value, pieces)| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,8 +202,8 @@ impl<T> PathTree<T> {
                     pieces,
                     // opt!
                     raws: ranges
-                        .chunks(2)
-                        .map(|r| from_utf8(&bytes[r[0]..r[1]]).unwrap())
+                        .into_iter()
+                        .map(|r| from_utf8(&bytes[r]).unwrap())
                         .rev()
                         .collect(),
                 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,6 +1,7 @@
 use std::{
     cmp::Ordering,
     fmt::{self, Write},
+    ops::Range,
 };
 
 use smallvec::SmallVec;
@@ -109,7 +110,7 @@ impl<T: fmt::Debug> Node<T> {
         &self,
         mut start: usize,
         mut bytes: &[u8],
-        ranges: &mut SmallVec<[usize; 8]>,
+        ranges: &mut SmallVec<[Range<usize>; 8]>,
     ) -> Option<&T> {
         let mut m = bytes.len();
         match &self.kind {
@@ -269,8 +270,7 @@ impl<T: fmt::Debug> Node<T> {
                             // last
                             if self.nodes0.is_none() && self.nodes1.is_none() {
                                 return self.value.as_ref().map(|id| {
-                                    ranges.push(start);
-                                    ranges.push(start);
+                                    ranges.push(start..start);
                                     id
                                 });
                             }
@@ -282,8 +282,7 @@ impl<T: fmt::Debug> Node<T> {
                                 NodeKind::String(s) => {
                                     bytes.iter().position(|b| s[0] == *b).and_then(|n| {
                                         node._find(start + n, &bytes[n..], ranges).map(|id| {
-                                            ranges.push(start);
-                                            ranges.push(start + n);
+                                            ranges.push(start..start + n);
                                             id
                                         })
                                     })
@@ -309,8 +308,7 @@ impl<T: fmt::Debug> Node<T> {
                                 })
                                 .find_map(|node| node._find(start + 1, &bytes[1..], ranges))
                         }) {
-                            ranges.push(start);
-                            ranges.push(start + 1);
+                            ranges.push(start..start + 1);
                             return Some(id);
                         }
                     }
@@ -332,8 +330,7 @@ impl<T: fmt::Debug> Node<T> {
                                 .find_map(|node| node._find(start, bytes, ranges))
                         }) {
                             // param should be empty
-                            ranges.push(start + m);
-                            ranges.push(start + m);
+                            ranges.push(start + m..start + m);
                             return Some(id);
                         }
                     }
@@ -342,8 +339,7 @@ impl<T: fmt::Debug> Node<T> {
                         bytes = &bytes[n..];
                     } else {
                         if let Some(id) = &self.value {
-                            ranges.push(start);
-                            ranges.push(start + m);
+                            ranges.push(start..start + m);
                             return Some(id);
                         }
                         bytes = &bytes[m..];
@@ -359,8 +355,7 @@ impl<T: fmt::Debug> Node<T> {
                                 })
                                 .and_then(|node| node._find(start, bytes, ranges))
                         }) {
-                            ranges.push(start);
-                            ranges.push(start + m);
+                            ranges.push(start..start + m);
                             return Some(id);
                         }
                     }
@@ -374,8 +369,7 @@ impl<T: fmt::Debug> Node<T> {
                             // last
                             if self.nodes0.is_none() && self.nodes1.is_none() {
                                 return self.value.as_ref().map(|id| {
-                                    ranges.push(start);
-                                    ranges.push(start);
+                                    ranges.push(start..start);
                                     id
                                 });
                             }
@@ -383,8 +377,7 @@ impl<T: fmt::Debug> Node<T> {
                     } else {
                         if self.nodes0.is_none() && self.nodes1.is_none() {
                             if let Some(id) = &self.value {
-                                ranges.push(start);
-                                ranges.push(start + m);
+                                ranges.push(start..start + m);
                                 return Some(id);
                             }
                         }
@@ -408,8 +401,7 @@ impl<T: fmt::Debug> Node<T> {
                                             .find_map(|n| {
                                                 node._find(start + n, &bytes[n..], ranges).map(
                                                     |id| {
-                                                        ranges.push(start);
-                                                        ranges.push(start + n);
+                                                        ranges.push(start..start + n);
                                                         id
                                                     },
                                                 )
@@ -434,8 +426,7 @@ impl<T: fmt::Debug> Node<T> {
                                 .and_then(|node| node._find(start, bytes, ranges))
                         }) {
                             // param should be empty
-                            ranges.push(start + m);
-                            ranges.push(start + m);
+                            ranges.push(start + m..start + m);
                             return Some(id);
                         }
                     }
@@ -445,8 +436,8 @@ impl<T: fmt::Debug> Node<T> {
         None
     }
 
-    pub fn find<'b>(&self, bytes: &'b [u8]) -> Option<(&T, SmallVec<[usize; 8]>)> {
-        let mut ranges = SmallVec::<[usize; 8]>::new(); // opt!
+    pub fn find<'b>(&self, bytes: &'b [u8]) -> Option<(&T, SmallVec<[Range<usize>; 8]>)> {
+        let mut ranges = SmallVec::<[Range<usize>; 8]>::new(); // opt!
         return self._find(0, bytes, &mut ranges).map(|t| (t, ranges));
     }
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,28 +1,29 @@
-use smallvec::SmallVec;
 use std::{
     cmp::Ordering,
     fmt::{self, Write},
 };
 
+use smallvec::SmallVec;
+
 use crate::Kind;
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum NodeKind<'a> {
-    String(&'a [u8]),
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum NodeKind {
+    String(Vec<u8>),
     Parameter(Kind),
 }
 
-pub struct Node<'a, T> {
+pub struct Node<T> {
     pub value: Option<T>,
-    pub kind: NodeKind<'a>,
+    pub kind: NodeKind,
     /// Stores string node
     pub nodes0: Option<Vec<Self>>,
     /// Stores parameter node
     pub nodes1: Option<Vec<Self>>,
 }
 
-impl<'a, T: fmt::Debug> Node<'a, T> {
-    pub fn new(kind: NodeKind<'a>, value: Option<T>) -> Self {
+impl<T: fmt::Debug> Node<T> {
+    pub fn new(kind: NodeKind, value: Option<T>) -> Self {
         Self {
             kind,
             value,
@@ -31,11 +32,11 @@ impl<'a, T: fmt::Debug> Node<'a, T> {
         }
     }
 
-    pub fn insert_bytes(&mut self, mut bytes: &'a [u8]) -> &mut Self {
+    pub fn insert_bytes(&mut self, mut bytes: &[u8]) -> &mut Self {
         let (cursor, diff) = match &mut self.kind {
             NodeKind::String(p) => {
                 if p.is_empty() {
-                    *p = bytes;
+                    *p = bytes.to_vec();
                     return self;
                 }
 
@@ -53,8 +54,8 @@ impl<'a, T: fmt::Debug> Node<'a, T> {
                         // split node
                         if cursor < p.len() {
                             let (prefix, suffix) = p.split_at(cursor);
-                            let mut node = Node::new(NodeKind::String(prefix), None);
-                            *p = suffix;
+                            let mut node = Node::new(NodeKind::String(prefix.to_vec()), None);
+                            *p = suffix.to_vec();
                             ::std::mem::swap(self, &mut node);
                             self.nodes0.get_or_insert_with(Vec::new).push(node);
                         }
@@ -69,7 +70,7 @@ impl<'a, T: fmt::Debug> Node<'a, T> {
         if diff {
             bytes = &bytes[cursor..];
             let nodes = self.nodes0.get_or_insert_with(Vec::new);
-            return match nodes.binary_search_by(|node| match node.kind {
+            return match nodes.binary_search_by(|node| match &node.kind {
                 NodeKind::String(s) => {
                     // s[0].cmp(&bytes[0])
                     // opt!
@@ -80,7 +81,7 @@ impl<'a, T: fmt::Debug> Node<'a, T> {
             }) {
                 Ok(i) => nodes[i].insert_bytes(bytes),
                 Err(i) => {
-                    nodes.insert(i, Node::new(NodeKind::String(bytes), None));
+                    nodes.insert(i, Node::new(NodeKind::String(bytes.to_vec()), None));
                     &mut nodes[i]
                 }
             };
@@ -111,7 +112,7 @@ impl<'a, T: fmt::Debug> Node<'a, T> {
         ranges: &mut SmallVec<[usize; 8]>,
     ) -> Option<&T> {
         let mut m = bytes.len();
-        match self.kind {
+        match &self.kind {
             NodeKind::String(s) => {
                 let n = s.len();
                 let mut flag = m >= n;
@@ -139,7 +140,7 @@ impl<'a, T: fmt::Debug> Node<'a, T> {
                         // static
                         if let Some(id) = self.nodes0.as_ref().and_then(|nodes| {
                             nodes
-                                .binary_search_by(|node| match node.kind {
+                                .binary_search_by(|node| match &node.kind {
                                     NodeKind::String(s) => {
                                         // s[0].cmp(&bytes[0])
                                         // opt!
@@ -262,7 +263,7 @@ impl<'a, T: fmt::Debug> Node<'a, T> {
                 // }
                 Kind::Normal | Kind::Optional | Kind::OptionalSegment => {
                     if m == 0 {
-                        if k == Kind::Normal {
+                        if k == &Kind::Normal {
                             return None;
                         } else {
                             // last
@@ -277,7 +278,7 @@ impl<'a, T: fmt::Debug> Node<'a, T> {
                     } else {
                         // static
                         if let Some(id) = self.nodes0.as_ref().and_then(|nodes| {
-                            nodes.iter().find_map(|node| match node.kind {
+                            nodes.iter().find_map(|node| match &node.kind {
                                 NodeKind::String(s) => {
                                     bytes.iter().position(|b| s[0] == *b).and_then(|n| {
                                         node._find(start + n, &bytes[n..], ranges).map(|id| {
@@ -315,14 +316,14 @@ impl<'a, T: fmt::Debug> Node<'a, T> {
                     }
 
                     // parameter => `:a:b?:c?`
-                    if k == Kind::Optional || k == Kind::OptionalSegment {
+                    if k == &Kind::Optional || k == &Kind::OptionalSegment {
                         if let Some(id) = self.nodes1.as_ref().and_then(|nodes| {
                             let b = m > 0;
                             nodes
                                 .iter()
-                                .filter(|node| match node.kind {
+                                .filter(|node| match &node.kind {
                                     NodeKind::Parameter(pk)
-                                        if pk == Kind::Normal || pk == Kind::OneOrMore =>
+                                        if pk == &Kind::Normal || pk == &Kind::OneOrMore =>
                                     {
                                         b
                                     }
@@ -348,11 +349,11 @@ impl<'a, T: fmt::Debug> Node<'a, T> {
                         bytes = &bytes[m..];
                     }
 
-                    if k == Kind::OptionalSegment {
+                    if k == &Kind::OptionalSegment {
                         if let Some(id) = self.nodes0.as_ref().and_then(|nodes| {
                             nodes
                                 .last()
-                                .filter(|node| match node.kind {
+                                .filter(|node| match &node.kind {
                                     NodeKind::String(s) => s[0] == b'/',
                                     _ => unreachable!(),
                                 })
@@ -365,7 +366,7 @@ impl<'a, T: fmt::Debug> Node<'a, T> {
                     }
                 }
                 Kind::OneOrMore | Kind::ZeroOrMore | Kind::ZeroOrMoreSegment => {
-                    let is_one_or_more = k == Kind::OneOrMore;
+                    let is_one_or_more = k == &Kind::OneOrMore;
                     if m == 0 {
                         if is_one_or_more {
                             return None;
@@ -391,7 +392,7 @@ impl<'a, T: fmt::Debug> Node<'a, T> {
                         // static
                         if let Some(id) = self.nodes0.as_ref().and_then(|nodes| {
                             nodes.iter().find_map(|node| {
-                                if let NodeKind::String(s) = node.kind {
+                                if let NodeKind::String(s) = &node.kind {
                                     let right_length = if is_one_or_more {
                                         m > s.len()
                                     } else {
@@ -422,11 +423,11 @@ impl<'a, T: fmt::Debug> Node<'a, T> {
                         }
                     }
 
-                    if k == Kind::ZeroOrMoreSegment {
+                    if k == &Kind::ZeroOrMoreSegment {
                         if let Some(id) = self.nodes0.as_ref().and_then(|nodes| {
                             nodes
                                 .last()
-                                .filter(|node| match node.kind {
+                                .filter(|node| match &node.kind {
                                     NodeKind::String(s) => s[0] == b'/',
                                     _ => unreachable!(),
                                 })
@@ -450,16 +451,16 @@ impl<'a, T: fmt::Debug> Node<'a, T> {
     }
 }
 
-impl<'a, T: fmt::Debug> fmt::Debug for Node<'a, T> {
+impl<T: fmt::Debug> fmt::Debug for Node<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const EDGE: &str = "├──";
         const LINE: &str = "│  ";
         const CORNER: &str = "└──";
         const BLANK: &str = "   ";
 
-        fn print_nodes<'a, T: fmt::Debug>(
+        fn print_nodes<T: fmt::Debug>(
             f: &mut fmt::Formatter<'_>,
-            nodes: &Vec<Node<'a, T>>,
+            nodes: &Vec<Node<T>>,
             check: bool,
             pad: &str,
             space: &str,
@@ -478,9 +479,9 @@ impl<'a, T: fmt::Debug> fmt::Debug for Node<'a, T> {
             Ok(())
         }
 
-        fn print_tree<'a, T: fmt::Debug>(
+        fn print_tree<T: fmt::Debug>(
             f: &mut fmt::Formatter<'_>,
-            node: &Node<'a, T>,
+            node: &Node<T>,
             root: bool,
             pad: &str,
         ) -> fmt::Result {

--- a/tests/node.rs
+++ b/tests/node.rs
@@ -2,7 +2,7 @@ use path_tree::*;
 
 #[test]
 fn github_nodes() {
-    let mut node = Node::<'static, usize>::new(NodeKind::String(b"/"), None);
+    let mut node = Node::<usize>::new(NodeKind::String(b"/".to_vec()), None);
 
     let mut n = node.insert_bytes(b"/");
     n = n.insert_parameter(Kind::Normal);

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -1,31 +1,30 @@
 use path_tree::*;
-use std::borrow::Cow;
 
 #[test]
 fn parses() {
     assert_eq!(
         Parser::new(r"/shop/product/\::filter/color\::color/size\::size").collect::<Vec<_>>(),
         [
-            Piece::String(b"/shop/product/"),
-            Piece::String(b":"),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"filter")), Kind::Normal),
-            Piece::String(b"/color"),
-            Piece::String(b":"),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"color")), Kind::Normal),
-            Piece::String(b"/size"),
-            Piece::String(b":"),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"size")), Kind::Normal),
+            Piece::String(b"/shop/product/".to_vec()),
+            Piece::String(b":".to_vec()),
+            Piece::Parameter(Position::Named(b"filter".to_vec()), Kind::Normal),
+            Piece::String(b"/color".to_vec()),
+            Piece::String(b":".to_vec()),
+            Piece::Parameter(Position::Named(b"color".to_vec()), Kind::Normal),
+            Piece::String(b"/size".to_vec()),
+            Piece::String(b":".to_vec()),
+            Piece::Parameter(Position::Named(b"size".to_vec()), Kind::Normal),
         ],
     );
 
     assert_eq!(
         Parser::new("/api/v1/:param/abc/*").collect::<Vec<_>>(),
         [
-            Piece::String(b"/api/v1/"),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"param")), Kind::Normal),
-            Piece::String(b"/abc/"),
+            Piece::String(b"/api/v1/".to_vec()),
+            Piece::Parameter(Position::Named(b"param".to_vec()), Kind::Normal),
+            Piece::String(b"/abc/".to_vec()),
             Piece::Parameter(
-                Position::Index(1, Cow::Borrowed(b"*1")),
+                Position::Index(1, b"*1".to_vec()),
                 Kind::ZeroOrMoreSegment
             ),
         ],
@@ -34,19 +33,19 @@ fn parses() {
     assert_eq!(
         Parser::new("/api/v1/:param/+").collect::<Vec<_>>(),
         [
-            Piece::String(b"/api/v1/"),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"param")), Kind::Normal),
-            Piece::String(b"/"),
-            Piece::Parameter(Position::Index(1, Cow::Borrowed(b"+1")), Kind::OneOrMore),
+            Piece::String(b"/api/v1/".to_vec()),
+            Piece::Parameter(Position::Named(b"param".to_vec()), Kind::Normal),
+            Piece::String(b"/".to_vec()),
+            Piece::Parameter(Position::Index(1, b"+1".to_vec()), Kind::OneOrMore),
         ],
     );
 
     assert_eq!(
         Parser::new("/api/v1/:param?").collect::<Vec<_>>(),
         [
-            Piece::String(b"/api/v1/"),
+            Piece::String(b"/api/v1/".to_vec()),
             Piece::Parameter(
-                Position::Named(Cow::Borrowed(b"param")),
+                Position::Named(b"param".to_vec()),
                 Kind::OptionalSegment
             ),
         ],
@@ -55,9 +54,9 @@ fn parses() {
     assert_eq!(
         Parser::new("/api/v1/:param?").collect::<Vec<_>>(),
         [
-            Piece::String(b"/api/v1/"),
+            Piece::String(b"/api/v1/".to_vec()),
             Piece::Parameter(
-                Position::Named(Cow::Borrowed(b"param")),
+                Position::Named(b"param".to_vec()),
                 Kind::OptionalSegment
             ),
         ],
@@ -66,17 +65,17 @@ fn parses() {
     assert_eq!(
         Parser::new("/api/v1/:param").collect::<Vec<_>>(),
         [
-            Piece::String(b"/api/v1/"),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"param")), Kind::Normal),
+            Piece::String(b"/api/v1/".to_vec()),
+            Piece::Parameter(Position::Named(b"param".to_vec()), Kind::Normal),
         ],
     );
 
     assert_eq!(
         Parser::new("/api/v1/*").collect::<Vec<_>>(),
         [
-            Piece::String(b"/api/v1/"),
+            Piece::String(b"/api/v1/".to_vec()),
             Piece::Parameter(
-                Position::Index(1, Cow::Borrowed(b"*1")),
+                Position::Index(1, b"*1".to_vec()),
                 Kind::ZeroOrMoreSegment
             ),
         ],
@@ -85,172 +84,172 @@ fn parses() {
     assert_eq!(
         Parser::new("/api/v1/:param-:param2").collect::<Vec<_>>(),
         [
-            Piece::String(b"/api/v1/"),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"param")), Kind::Normal),
-            Piece::String(b"-"),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"param2")), Kind::Normal),
+            Piece::String(b"/api/v1/".to_vec()),
+            Piece::Parameter(Position::Named(b"param".to_vec()), Kind::Normal),
+            Piece::String(b"-".to_vec()),
+            Piece::Parameter(Position::Named(b"param2".to_vec()), Kind::Normal),
         ],
     );
 
     assert_eq!(
         Parser::new("/api/v1/:filename.:extension").collect::<Vec<_>>(),
         [
-            Piece::String(b"/api/v1/"),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"filename")), Kind::Normal),
-            Piece::String(b"."),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"extension")), Kind::Normal),
+            Piece::String(b"/api/v1/".to_vec()),
+            Piece::Parameter(Position::Named(b"filename".to_vec()), Kind::Normal),
+            Piece::String(b".".to_vec()),
+            Piece::Parameter(Position::Named(b"extension".to_vec()), Kind::Normal),
         ],
     );
 
     assert_eq!(
         Parser::new("/api/v1/string").collect::<Vec<_>>(),
-        [Piece::String(b"/api/v1/string"),],
+        [Piece::String(b"/api/v1/string".to_vec()),],
     );
 
     assert_eq!(
         Parser::new(r"/\::param?").collect::<Vec<_>>(),
         [
-            Piece::String(b"/"),
-            Piece::String(b":"),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"param")), Kind::Optional),
+            Piece::String(b"/".to_vec()),
+            Piece::String(b":".to_vec()),
+            Piece::Parameter(Position::Named(b"param".to_vec()), Kind::Optional),
         ],
     );
 
     assert_eq!(
         Parser::new("/:param1:param2?:param3").collect::<Vec<_>>(),
         [
-            Piece::String(b"/"),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"param1")), Kind::Normal),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"param2")), Kind::Optional),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"param3")), Kind::Normal),
+            Piece::String(b"/".to_vec()),
+            Piece::Parameter(Position::Named(b"param1".to_vec()), Kind::Normal),
+            Piece::Parameter(Position::Named(b"param2".to_vec()), Kind::Optional),
+            Piece::Parameter(Position::Named(b"param3".to_vec()), Kind::Normal),
         ],
     );
 
     assert_eq!(
         Parser::new("/test:sign:param").collect::<Vec<_>>(),
         [
-            Piece::String(b"/test"),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"sign")), Kind::Normal),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"param")), Kind::Normal),
+            Piece::String(b"/test".to_vec()),
+            Piece::Parameter(Position::Named(b"sign".to_vec()), Kind::Normal),
+            Piece::Parameter(Position::Named(b"param".to_vec()), Kind::Normal),
         ],
     );
 
     assert_eq!(
         Parser::new("/foo:param?bar").collect::<Vec<_>>(),
         [
-            Piece::String(b"/foo"),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"param")), Kind::Optional),
-            Piece::String(b"bar"),
+            Piece::String(b"/foo".to_vec()),
+            Piece::Parameter(Position::Named(b"param".to_vec()), Kind::Optional),
+            Piece::String(b"bar".to_vec()),
         ],
     );
 
     assert_eq!(
         Parser::new("/foo*bar").collect::<Vec<_>>(),
         [
-            Piece::String(b"/foo"),
-            Piece::Parameter(Position::Index(1, Cow::Borrowed(b"*1")), Kind::ZeroOrMore),
-            Piece::String(b"bar"),
+            Piece::String(b"/foo".to_vec()),
+            Piece::Parameter(Position::Index(1, b"*1".to_vec()), Kind::ZeroOrMore),
+            Piece::String(b"bar".to_vec()),
         ],
     );
 
     assert_eq!(
         Parser::new("/foo+bar").collect::<Vec<_>>(),
         [
-            Piece::String(b"/foo"),
-            Piece::Parameter(Position::Index(1, Cow::Borrowed(b"+1")), Kind::OneOrMore),
-            Piece::String(b"bar"),
+            Piece::String(b"/foo".to_vec()),
+            Piece::Parameter(Position::Index(1, b"+1".to_vec()), Kind::OneOrMore),
+            Piece::String(b"bar".to_vec()),
         ],
     );
 
     assert_eq!(
         Parser::new("/a*cde*g/").collect::<Vec<_>>(),
         [
-            Piece::String(b"/a"),
-            Piece::Parameter(Position::Index(1, Cow::Borrowed(b"*1")), Kind::ZeroOrMore),
-            Piece::String(b"cde"),
-            Piece::Parameter(Position::Index(2, Cow::Borrowed(b"*2")), Kind::ZeroOrMore),
-            Piece::String(b"g/"),
+            Piece::String(b"/a".to_vec()),
+            Piece::Parameter(Position::Index(1, b"*1".to_vec()), Kind::ZeroOrMore),
+            Piece::String(b"cde".to_vec()),
+            Piece::Parameter(Position::Index(2, b"*2".to_vec()), Kind::ZeroOrMore),
+            Piece::String(b"g/".to_vec()),
         ],
     );
 
     assert_eq!(
         Parser::new(r"/name\::name").collect::<Vec<_>>(),
         [
-            Piece::String(b"/name"),
-            Piece::String(b":"),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"name")), Kind::Normal),
+            Piece::String(b"/name".to_vec()),
+            Piece::String(b":".to_vec()),
+            Piece::Parameter(Position::Named(b"name".to_vec()), Kind::Normal),
         ]
     );
 
     assert_eq!(
         Parser::new("/@:name").collect::<Vec<_>>(),
         [
-            Piece::String(b"/@"),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"name")), Kind::Normal),
+            Piece::String(b"/@".to_vec()),
+            Piece::Parameter(Position::Named(b"name".to_vec()), Kind::Normal),
         ]
     );
 
     assert_eq!(
         Parser::new("/-:name").collect::<Vec<_>>(),
         [
-            Piece::String(b"/-"),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"name")), Kind::Normal),
+            Piece::String(b"/-".to_vec()),
+            Piece::Parameter(Position::Named(b"name".to_vec()), Kind::Normal),
         ]
     );
 
     assert_eq!(
         Parser::new("/.:name").collect::<Vec<_>>(),
         [
-            Piece::String(b"/."),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"name")), Kind::Normal),
+            Piece::String(b"/.".to_vec()),
+            Piece::Parameter(Position::Named(b"name".to_vec()), Kind::Normal),
         ]
     );
 
     assert_eq!(
         Parser::new("/_:name").collect::<Vec<_>>(),
         [
-            Piece::String(b"/_"),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"name")), Kind::Normal),
+            Piece::String(b"/_".to_vec()),
+            Piece::Parameter(Position::Named(b"name".to_vec()), Kind::Normal),
         ]
     );
 
     assert_eq!(
         Parser::new("/~:name").collect::<Vec<_>>(),
         [
-            Piece::String(b"/~"),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"name")), Kind::Normal),
+            Piece::String(b"/~".to_vec()),
+            Piece::Parameter(Position::Named(b"name".to_vec()), Kind::Normal),
         ]
     );
 
     assert_eq!(
         Parser::new("/v1/some/resource/name\\:customVerb").collect::<Vec<_>>(),
         [
-            Piece::String(b"/v1/some/resource/name"),
-            Piece::String(b":"),
-            Piece::String(b"customVerb"),
+            Piece::String(b"/v1/some/resource/name".to_vec()),
+            Piece::String(b":".to_vec()),
+            Piece::String(b"customVerb".to_vec()),
         ],
     );
 
     assert_eq!(
         Parser::new("/v1/some/resource/:name\\:customVerb").collect::<Vec<_>>(),
         [
-            Piece::String(b"/v1/some/resource/"),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"name")), Kind::Normal),
-            Piece::String(b":"),
-            Piece::String(b"customVerb"),
+            Piece::String(b"/v1/some/resource/".to_vec()),
+            Piece::Parameter(Position::Named(b"name".to_vec()), Kind::Normal),
+            Piece::String(b":".to_vec()),
+            Piece::String(b"customVerb".to_vec()),
         ],
     );
 
     assert_eq!(
         Parser::new("/v1/some/resource/name\\:customVerb??/:param/*").collect::<Vec<_>>(),
         [
-            Piece::String(b"/v1/some/resource/name"),
-            Piece::String(b":"),
-            Piece::String(b"customVerb??/"),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"param")), Kind::Normal),
-            Piece::String(b"/"),
+            Piece::String(b"/v1/some/resource/name".to_vec()),
+            Piece::String(b":".to_vec()),
+            Piece::String(b"customVerb??/".to_vec()),
+            Piece::Parameter(Position::Named(b"param".to_vec()), Kind::Normal),
+            Piece::String(b"/".to_vec()),
             Piece::Parameter(
-                Position::Index(1, Cow::Borrowed(b"*1")),
+                Position::Index(1, b"*1".to_vec()),
                 Kind::ZeroOrMoreSegment
             )
         ],
@@ -259,70 +258,70 @@ fn parses() {
     assert_eq!(
         Parser::new("/api/*/:param/:param2").collect::<Vec<_>>(),
         [
-            Piece::String(b"/api/"),
+            Piece::String(b"/api/".to_vec()),
             Piece::Parameter(
-                Position::Index(1, Cow::Borrowed(b"*1")),
+                Position::Index(1, b"*1".to_vec()),
                 Kind::ZeroOrMoreSegment
             ),
-            Piece::String(b"/"),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"param")), Kind::Normal),
-            Piece::String(b"/"),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"param2")), Kind::Normal)
+            Piece::String(b"/".to_vec()),
+            Piece::Parameter(Position::Named(b"param".to_vec()), Kind::Normal),
+            Piece::String(b"/".to_vec()),
+            Piece::Parameter(Position::Named(b"param2".to_vec()), Kind::Normal)
         ],
     );
 
     assert_eq!(
         Parser::new("/test:optional?:optional2?").collect::<Vec<_>>(),
         [
-            Piece::String(b"/test"),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"optional")), Kind::Optional),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"optional2")), Kind::Optional)
+            Piece::String(b"/test".to_vec()),
+            Piece::Parameter(Position::Named(b"optional".to_vec()), Kind::Optional),
+            Piece::Parameter(Position::Named(b"optional2".to_vec()), Kind::Optional)
         ],
     );
 
     assert_eq!(
         Parser::new("/config/+.json").collect::<Vec<_>>(),
         [
-            Piece::String(b"/config/"),
-            Piece::Parameter(Position::Index(1, Cow::Borrowed(b"+1")), Kind::OneOrMore),
-            Piece::String(b".json")
+            Piece::String(b"/config/".to_vec()),
+            Piece::Parameter(Position::Index(1, b"+1".to_vec()), Kind::OneOrMore),
+            Piece::String(b".json".to_vec()),
         ]
     );
 
     assert_eq!(
         Parser::new("/config/*.json").collect::<Vec<_>>(),
         [
-            Piece::String(b"/config/"),
-            Piece::Parameter(Position::Index(1, Cow::Borrowed(b"*1")), Kind::ZeroOrMore),
-            Piece::String(b".json")
+            Piece::String(b"/config/".to_vec()),
+            Piece::Parameter(Position::Index(1, b"*1".to_vec()), Kind::ZeroOrMore),
+            Piece::String(b".json".to_vec()),
         ]
     );
 
     assert_eq!(
         Parser::new("/api/:day.:month?.:year?").collect::<Vec<_>>(),
         [
-            Piece::String(b"/api/"),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"day")), Kind::Normal),
-            Piece::String(b"."),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"month")), Kind::Optional),
-            Piece::String(b"."),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"year")), Kind::Optional),
+            Piece::String(b"/api/".to_vec()),
+            Piece::Parameter(Position::Named(b"day".to_vec()), Kind::Normal),
+            Piece::String(b".".to_vec()),
+            Piece::Parameter(Position::Named(b"month".to_vec()), Kind::Optional),
+            Piece::String(b".".to_vec()),
+            Piece::Parameter(Position::Named(b"year".to_vec()), Kind::Optional),
         ]
     );
 
     assert_eq!(
         Parser::new("/api/:day/:month?/:year?").collect::<Vec<_>>(),
         [
-            Piece::String(b"/api/"),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"day")), Kind::Normal),
-            Piece::String(b"/"),
+            Piece::String(b"/api/".to_vec()),
+            Piece::Parameter(Position::Named(b"day".to_vec()), Kind::Normal),
+            Piece::String(b"/".to_vec()),
             Piece::Parameter(
-                Position::Named(Cow::Borrowed(b"month")),
+                Position::Named(b"month".to_vec()),
                 Kind::OptionalSegment
             ),
-            Piece::String(b"/"),
+            Piece::String(b"/".to_vec()),
             Piece::Parameter(
-                Position::Named(Cow::Borrowed(b"year")),
+                Position::Named(b"year".to_vec()),
                 Kind::OptionalSegment
             ),
         ]
@@ -331,22 +330,22 @@ fn parses() {
     assert_eq!(
         Parser::new("/*v1*/proxy").collect::<Vec<_>>(),
         [
-            Piece::String(b"/"),
-            Piece::Parameter(Position::Index(1, Cow::Borrowed(b"*1")), Kind::ZeroOrMore),
-            Piece::String(b"v1"),
-            Piece::Parameter(Position::Index(2, Cow::Borrowed(b"*2")), Kind::ZeroOrMore),
-            Piece::String(b"/proxy")
+            Piece::String(b"/".to_vec()),
+            Piece::Parameter(Position::Index(1, b"*1".to_vec()), Kind::ZeroOrMore),
+            Piece::String(b"v1".to_vec()),
+            Piece::Parameter(Position::Index(2, b"*2".to_vec()), Kind::ZeroOrMore),
+            Piece::String(b"/proxy".to_vec()),
         ]
     );
 
     assert_eq!(
         Parser::new("/:a*v1:b+/proxy").collect::<Vec<_>>(),
         [
-            Piece::String(b"/"),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"a")), Kind::ZeroOrMore),
-            Piece::String(b"v1"),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"b")), Kind::OneOrMore),
-            Piece::String(b"/proxy")
+            Piece::String(b"/".to_vec()),
+            Piece::Parameter(Position::Named(b"a".to_vec()), Kind::ZeroOrMore),
+            Piece::String(b"v1".to_vec()),
+            Piece::Parameter(Position::Named(b"b".to_vec()), Kind::OneOrMore),
+            Piece::String(b"/proxy".to_vec()),
         ]
     );
 }

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -23,10 +23,7 @@ fn parses() {
             Piece::String(b"/api/v1/".to_vec()),
             Piece::Parameter(Position::Named(b"param".to_vec()), Kind::Normal),
             Piece::String(b"/abc/".to_vec()),
-            Piece::Parameter(
-                Position::Index(1, b"*1".to_vec()),
-                Kind::ZeroOrMoreSegment
-            ),
+            Piece::Parameter(Position::Index(1, b"*1".to_vec()), Kind::ZeroOrMoreSegment),
         ],
     );
 
@@ -44,10 +41,7 @@ fn parses() {
         Parser::new("/api/v1/:param?").collect::<Vec<_>>(),
         [
             Piece::String(b"/api/v1/".to_vec()),
-            Piece::Parameter(
-                Position::Named(b"param".to_vec()),
-                Kind::OptionalSegment
-            ),
+            Piece::Parameter(Position::Named(b"param".to_vec()), Kind::OptionalSegment),
         ],
     );
 
@@ -55,10 +49,7 @@ fn parses() {
         Parser::new("/api/v1/:param?").collect::<Vec<_>>(),
         [
             Piece::String(b"/api/v1/".to_vec()),
-            Piece::Parameter(
-                Position::Named(b"param".to_vec()),
-                Kind::OptionalSegment
-            ),
+            Piece::Parameter(Position::Named(b"param".to_vec()), Kind::OptionalSegment),
         ],
     );
 
@@ -74,10 +65,7 @@ fn parses() {
         Parser::new("/api/v1/*").collect::<Vec<_>>(),
         [
             Piece::String(b"/api/v1/".to_vec()),
-            Piece::Parameter(
-                Position::Index(1, b"*1".to_vec()),
-                Kind::ZeroOrMoreSegment
-            ),
+            Piece::Parameter(Position::Index(1, b"*1".to_vec()), Kind::ZeroOrMoreSegment),
         ],
     );
 
@@ -248,10 +236,7 @@ fn parses() {
             Piece::String(b"customVerb??/".to_vec()),
             Piece::Parameter(Position::Named(b"param".to_vec()), Kind::Normal),
             Piece::String(b"/".to_vec()),
-            Piece::Parameter(
-                Position::Index(1, b"*1".to_vec()),
-                Kind::ZeroOrMoreSegment
-            )
+            Piece::Parameter(Position::Index(1, b"*1".to_vec()), Kind::ZeroOrMoreSegment)
         ],
     );
 
@@ -259,10 +244,7 @@ fn parses() {
         Parser::new("/api/*/:param/:param2").collect::<Vec<_>>(),
         [
             Piece::String(b"/api/".to_vec()),
-            Piece::Parameter(
-                Position::Index(1, b"*1".to_vec()),
-                Kind::ZeroOrMoreSegment
-            ),
+            Piece::Parameter(Position::Index(1, b"*1".to_vec()), Kind::ZeroOrMoreSegment),
             Piece::String(b"/".to_vec()),
             Piece::Parameter(Position::Named(b"param".to_vec()), Kind::Normal),
             Piece::String(b"/".to_vec()),
@@ -315,15 +297,9 @@ fn parses() {
             Piece::String(b"/api/".to_vec()),
             Piece::Parameter(Position::Named(b"day".to_vec()), Kind::Normal),
             Piece::String(b"/".to_vec()),
-            Piece::Parameter(
-                Position::Named(b"month".to_vec()),
-                Kind::OptionalSegment
-            ),
+            Piece::Parameter(Position::Named(b"month".to_vec()), Kind::OptionalSegment),
             Piece::String(b"/".to_vec()),
-            Piece::Parameter(
-                Position::Named(b"year".to_vec()),
-                Kind::OptionalSegment
-            ),
+            Piece::Parameter(Position::Named(b"year".to_vec()), Kind::OptionalSegment),
         ]
     );
 

--- a/tests/tree.rs
+++ b/tests/tree.rs
@@ -1,5 +1,3 @@
-use std::borrow::Cow;
-
 use path_tree::*;
 use rand::seq::SliceRandom;
 
@@ -23,7 +21,7 @@ fn statics() {
 
     routes.shuffle(&mut rand::thread_rng());
 
-    let mut tree = PathTree::<'static, usize>::new();
+    let mut tree = PathTree::<usize>::new();
 
     for (i, u) in routes.iter().enumerate() {
         tree.insert(u, i);
@@ -474,7 +472,7 @@ fn match_params() {
     //     └── :
     //         └── /
     //             └── ** •0
-    let mut tree = PathTree::<'static, usize>::new();
+    let mut tree = PathTree::<usize>::new();
 
     tree.insert("/api/v1/:param/*", 1);
 
@@ -487,11 +485,11 @@ fn match_params() {
     assert_eq!(
         p.pieces,
         &vec![
-            Piece::String(b"/api/v1/"),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"param")), Kind::Normal),
-            Piece::String(b"/"),
+            Piece::String(b"/api/v1/".to_vec()),
+            Piece::Parameter(Position::Named(b"param".to_vec()), Kind::Normal),
+            Piece::String(b"/".to_vec()),
             Piece::Parameter(
-                Position::Index(1, Cow::Borrowed(b"*1")),
+                Position::Index(1, b"*1".to_vec()),
                 Kind::ZeroOrMoreSegment
             ),
         ]
@@ -514,7 +512,7 @@ fn match_params() {
     //     └── :
     //         └── /
     //             └── + •0
-    let mut tree = PathTree::<'static, usize>::new();
+    let mut tree = PathTree::<usize>::new();
 
     tree.insert("/api/v1/:param/+", 1);
 
@@ -536,7 +534,7 @@ fn match_params() {
     // /
     // └── api/v1/
     //     └── ?? •0
-    let mut tree = PathTree::<'static, usize>::new();
+    let mut tree = PathTree::<usize>::new();
 
     tree.insert("/api/v1/:param?", 1);
 
@@ -548,9 +546,9 @@ fn match_params() {
     assert_eq!(
         p.pieces,
         &vec![
-            Piece::String(b"/api/v1/"),
+            Piece::String(b"/api/v1/".to_vec()),
             Piece::Parameter(
-                Position::Named(Cow::Borrowed(b"param")),
+                Position::Named(b"param".to_vec()),
                 Kind::OptionalSegment
             ),
         ]
@@ -565,7 +563,7 @@ fn match_params() {
     // └── v1/some/resource/name
     //     └── \:
     //         └── customVerb •0
-    let mut tree = PathTree::<'static, usize>::new();
+    let mut tree = PathTree::<usize>::new();
 
     tree.insert("/v1/some/resource/name\\:customVerb", 1);
 
@@ -577,9 +575,9 @@ fn match_params() {
     assert_eq!(
         p.pieces,
         &vec![
-            Piece::String(b"/v1/some/resource/name"),
-            Piece::String(b":"),
-            Piece::String(b"customVerb"),
+            Piece::String(b"/v1/some/resource/name".to_vec()),
+            Piece::String(b":".to_vec()),
+            Piece::String(b"customVerb".to_vec()),
         ]
     );
     assert_eq!(tree.find("/v1/some/resource/name:test"), None);
@@ -589,7 +587,7 @@ fn match_params() {
     //     └── :
     //         └── \:
     //             └── customVerb •0
-    let mut tree = PathTree::<'static, usize>::new();
+    let mut tree = PathTree::<usize>::new();
 
     tree.insert(r"/v1/some/resource/:name\:customVerb", 1);
 
@@ -600,10 +598,10 @@ fn match_params() {
     assert_eq!(
         p.pieces,
         vec![
-            Piece::String(b"/v1/some/resource/"),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"name")), Kind::Normal),
-            Piece::String(b":"),
-            Piece::String(b"customVerb"),
+            Piece::String(b"/v1/some/resource/".to_vec()),
+            Piece::Parameter(Position::Named(b"name".to_vec()), Kind::Normal),
+            Piece::String(b":".to_vec()),
+            Piece::String(b"customVerb".to_vec()),
         ]
     );
     assert_eq!(tree.find("/v1/some/resource/test:test"), None);
@@ -617,7 +615,7 @@ fn match_params() {
     //                     └── :
     //                         └── /
     //                             └── ** •0
-    let mut tree = PathTree::<'static, usize>::new();
+    let mut tree = PathTree::<usize>::new();
 
     tree.insert(r"/v1/some/resource/name\\\\:customVerb?\?/:param/*", 1);
 
@@ -641,7 +639,7 @@ fn match_params() {
     // /
     // └── api/v1/
     //     └── ** •0
-    let mut tree = PathTree::<'static, usize>::new();
+    let mut tree = PathTree::<usize>::new();
 
     tree.insert("/api/v1/*", 1);
 
@@ -666,7 +664,7 @@ fn match_params() {
     // /
     // └── api/v1/
     //     └── : •0
-    let mut tree = PathTree::<'static, usize>::new();
+    let mut tree = PathTree::<usize>::new();
 
     tree.insert("/api/v1/:param", 1);
 
@@ -695,7 +693,7 @@ fn match_params() {
     //         │   └── : •2
     //         └── /
     //             └── : •0
-    let mut tree = PathTree::<'static, usize>::new();
+    let mut tree = PathTree::<usize>::new();
 
     tree.insert("/api/v1/:param/:param2", 3);
     tree.insert("/api/v1/:param-:param2", 1);
@@ -737,7 +735,7 @@ fn match_params() {
 
     // /
     // └── api/v1/const •0
-    let mut tree = PathTree::<'static, usize>::new();
+    let mut tree = PathTree::<usize>::new();
 
     tree.insert("/api/v1/const", 1);
 
@@ -746,7 +744,7 @@ fn match_params() {
     assert_eq!(*p.value, 1);
     assert!(p.params().is_empty());
     assert_eq!(p.pattern(), "/api/v1/const");
-    assert_eq!(p.pieces, vec![Piece::String(b"/api/v1/const")]);
+    assert_eq!(p.pieces, vec![Piece::String(b"/api/v1/const".to_vec())]);
 
     assert_eq!(tree.find("/api/v1/cons"), None);
     assert_eq!(tree.find("/api/v1/conststatic"), None);
@@ -758,7 +756,7 @@ fn match_params() {
     // └── api/
     //     └── :
     //         └── /fixedEnd •0
-    let mut tree = PathTree::<'static, usize>::new();
+    let mut tree = PathTree::<usize>::new();
 
     tree.insert("/api/:param/fixedEnd", 1);
 
@@ -768,9 +766,9 @@ fn match_params() {
     assert_eq!(
         p.pieces,
         &vec![
-            Piece::String(b"/api/"),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"param")), Kind::Normal),
-            Piece::String(b"/fixedEnd"),
+            Piece::String(b"/api/".to_vec()),
+            Piece::Parameter(Position::Named(b"param".to_vec()), Kind::Normal),
+            Piece::String(b"/fixedEnd".to_vec()),
         ]
     );
     assert_eq!(p.params(), vec![("param", "abc")]);
@@ -788,7 +786,7 @@ fn match_params() {
     //                         └── /size
     //                             └── \:
     //                                 └── : •0
-    let mut tree = PathTree::<'static, usize>::new();
+    let mut tree = PathTree::<usize>::new();
 
     tree.insert(r"/shop/product/\::filter/color\::color/size\::size", 1);
 
@@ -798,15 +796,15 @@ fn match_params() {
     assert_eq!(
         p.pieces,
         &vec![
-            Piece::String(b"/shop/product/"),
-            Piece::String(b":"),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"filter")), Kind::Normal),
-            Piece::String(b"/color"),
-            Piece::String(b":"),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"color")), Kind::Normal),
-            Piece::String(b"/size"),
-            Piece::String(b":"),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"size")), Kind::Normal),
+            Piece::String(b"/shop/product/".to_vec()),
+            Piece::String(b":".to_vec()),
+            Piece::Parameter(Position::Named(b"filter".to_vec()), Kind::Normal),
+            Piece::String(b"/color".to_vec()),
+            Piece::String(b":".to_vec()),
+            Piece::Parameter(Position::Named(b"color".to_vec()), Kind::Normal),
+            Piece::String(b"/size".to_vec()),
+            Piece::String(b":".to_vec()),
+            Piece::Parameter(Position::Named(b"size".to_vec()), Kind::Normal),
         ]
     );
     assert_eq!(
@@ -823,7 +821,7 @@ fn match_params() {
     // /
     // └── \:
     //     └── ? •0
-    let mut tree = PathTree::<'static, usize>::new();
+    let mut tree = PathTree::<usize>::new();
 
     tree.insert("/\\::param?", 1);
 
@@ -835,9 +833,9 @@ fn match_params() {
     assert_eq!(
         p.pieces,
         &vec![
-            Piece::String(b"/"),
-            Piece::String(b":"),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"param")), Kind::Optional),
+            Piece::String(b"/".to_vec()),
+            Piece::String(b":".to_vec()),
+            Piece::Parameter(Position::Named(b"param".to_vec()), Kind::Optional),
         ]
     );
 
@@ -851,7 +849,7 @@ fn match_params() {
     // └── test
     //     └── :
     //         └── : •0
-    let mut tree = PathTree::<'static, usize>::new();
+    let mut tree = PathTree::<usize>::new();
 
     tree.insert("/test:sign:param", 1);
 
@@ -863,9 +861,9 @@ fn match_params() {
     assert_eq!(
         p.pieces,
         &vec![
-            Piece::String(b"/test"),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"sign")), Kind::Normal),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"param")), Kind::Normal),
+            Piece::String(b"/test".to_vec()),
+            Piece::Parameter(Position::Named(b"sign".to_vec()), Kind::Normal),
+            Piece::Parameter(Position::Named(b"param".to_vec()), Kind::Normal),
         ]
     );
 
@@ -880,7 +878,7 @@ fn match_params() {
     // └── :
     //     └── ?
     //         └── : •0
-    let mut tree = PathTree::<'static, usize>::new();
+    let mut tree = PathTree::<usize>::new();
 
     tree.insert("/:param1:param2?:param3", 1);
 
@@ -895,10 +893,10 @@ fn match_params() {
     assert_eq!(
         p.pieces,
         &vec![
-            Piece::String(b"/"),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"param1")), Kind::Normal),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"param2")), Kind::Optional),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"param3")), Kind::Normal),
+            Piece::String(b"/".to_vec()),
+            Piece::Parameter(Position::Named(b"param1".to_vec()), Kind::Normal),
+            Piece::Parameter(Position::Named(b"param2".to_vec()), Kind::Optional),
+            Piece::Parameter(Position::Named(b"param3".to_vec()), Kind::Normal),
         ]
     );
 
@@ -915,7 +913,7 @@ fn match_params() {
     // └── test
     //     └── ?
     //         └── : •0
-    let mut tree = PathTree::<'static, usize>::new();
+    let mut tree = PathTree::<usize>::new();
 
     tree.insert("/test:optional?:mandatory", 1);
 
@@ -927,9 +925,9 @@ fn match_params() {
     assert_eq!(
         p.pieces,
         &vec![
-            Piece::String(b"/test"),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"optional")), Kind::Optional),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"mandatory")), Kind::Normal),
+            Piece::String(b"/test".to_vec()),
+            Piece::Parameter(Position::Named(b"optional".to_vec()), Kind::Optional),
+            Piece::Parameter(Position::Named(b"mandatory".to_vec()), Kind::Normal),
         ]
     );
 
@@ -944,7 +942,7 @@ fn match_params() {
     // └── test
     //     └── ?
     //         └── ? •0
-    let mut tree = PathTree::<'static, usize>::new();
+    let mut tree = PathTree::<usize>::new();
 
     tree.insert("/test:optional?:optional2?", 1);
 
@@ -956,9 +954,9 @@ fn match_params() {
     assert_eq!(
         p.pieces,
         &vec![
-            Piece::String(b"/test"),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"optional")), Kind::Optional),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"optional2")), Kind::Optional),
+            Piece::String(b"/test".to_vec()),
+            Piece::Parameter(Position::Named(b"optional".to_vec()), Kind::Optional),
+            Piece::Parameter(Position::Named(b"optional2".to_vec()), Kind::Optional),
         ]
     );
 
@@ -976,7 +974,7 @@ fn match_params() {
     // └── foo
     //     └── ?
     //         └── bar •0
-    let mut tree = PathTree::<'static, usize>::new();
+    let mut tree = PathTree::<usize>::new();
 
     tree.insert("/foo:param?bar", 1);
 
@@ -988,9 +986,9 @@ fn match_params() {
     assert_eq!(
         p.pieces,
         &vec![
-            Piece::String(b"/foo"),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"param")), Kind::Optional),
-            Piece::String(b"bar"),
+            Piece::String(b"/foo".to_vec()),
+            Piece::Parameter(Position::Named(b"param".to_vec()), Kind::Optional),
+            Piece::String(b"bar".to_vec()),
         ]
     );
 
@@ -1005,7 +1003,7 @@ fn match_params() {
     // └── foo
     //     └── *
     //         └── bar •0
-    let mut tree = PathTree::<'static, usize>::new();
+    let mut tree = PathTree::<usize>::new();
 
     tree.insert("/foo*bar", 1);
 
@@ -1017,9 +1015,9 @@ fn match_params() {
     assert_eq!(
         p.pieces,
         &vec![
-            Piece::String(b"/foo"),
-            Piece::Parameter(Position::Index(1, Cow::Borrowed(b"*1")), Kind::ZeroOrMore),
-            Piece::String(b"bar"),
+            Piece::String(b"/foo".to_vec()),
+            Piece::Parameter(Position::Index(1, b"*1".to_vec()), Kind::ZeroOrMore),
+            Piece::String(b"bar".to_vec()),
         ]
     );
 
@@ -1042,7 +1040,7 @@ fn match_params() {
     // └── foo
     //     └── +
     //         └── bar •0
-    let mut tree = PathTree::<'static, usize>::new();
+    let mut tree = PathTree::<usize>::new();
 
     tree.insert("/foo+bar", 1);
 
@@ -1054,9 +1052,9 @@ fn match_params() {
     assert_eq!(
         p.pieces,
         &vec![
-            Piece::String(b"/foo"),
-            Piece::Parameter(Position::Index(1, Cow::Borrowed(b"+1")), Kind::OneOrMore),
-            Piece::String(b"bar"),
+            Piece::String(b"/foo".to_vec()),
+            Piece::Parameter(Position::Index(1, b"+1".to_vec()), Kind::OneOrMore),
+            Piece::String(b"bar".to_vec()),
         ]
     );
 
@@ -1079,7 +1077,7 @@ fn match_params() {
     //         └── cde
     //             └── *
     //                 └── g/ •0
-    let mut tree = PathTree::<'static, usize>::new();
+    let mut tree = PathTree::<usize>::new();
 
     tree.insert("/a*cde*g/", 1);
 
@@ -1090,11 +1088,11 @@ fn match_params() {
     assert_eq!(
         p.pieces,
         vec![
-            Piece::String(b"/a"),
-            Piece::Parameter(Position::Index(1, Cow::Borrowed(b"*1")), Kind::ZeroOrMore),
-            Piece::String(b"cde"),
-            Piece::Parameter(Position::Index(2, Cow::Borrowed(b"*2")), Kind::ZeroOrMore),
-            Piece::String(b"g/"),
+            Piece::String(b"/a".to_vec()),
+            Piece::Parameter(Position::Index(1, b"*1".to_vec()), Kind::ZeroOrMore),
+            Piece::String(b"cde".to_vec()),
+            Piece::Parameter(Position::Index(2, b"*2".to_vec()), Kind::ZeroOrMore),
+            Piece::String(b"g/".to_vec()),
         ]
     );
     assert_eq!(p.pattern(), "/a*cde*g/");
@@ -1123,7 +1121,7 @@ fn match_params() {
     //     └── v1
     //         └── *
     //             └── proxy/ •0
-    let mut tree = PathTree::<'static, usize>::new();
+    let mut tree = PathTree::<usize>::new();
 
     tree.insert("/*v1*/proxy", 1);
 
@@ -1132,11 +1130,11 @@ fn match_params() {
     assert_eq!(
         p.pieces,
         vec![
-            Piece::String(b"/"),
-            Piece::Parameter(Position::Index(1, Cow::Borrowed(b"*1")), Kind::ZeroOrMore),
-            Piece::String(b"v1"),
-            Piece::Parameter(Position::Index(2, Cow::Borrowed(b"*2")), Kind::ZeroOrMore),
-            Piece::String(b"/proxy"),
+            Piece::String(b"/".to_vec()),
+            Piece::Parameter(Position::Index(1, b"*1".to_vec()), Kind::ZeroOrMore),
+            Piece::String(b"v1".to_vec()),
+            Piece::Parameter(Position::Index(2, b"*2".to_vec()), Kind::ZeroOrMore),
+            Piece::String(b"/proxy".to_vec()),
         ]
     );
     assert_eq!(p.pattern(), "/*v1*/proxy");
@@ -1162,7 +1160,7 @@ fn match_params() {
     // ├── ~
     // │   └── : •4
     // └── : •6
-    let mut tree = PathTree::<'static, usize>::new();
+    let mut tree = PathTree::<usize>::new();
 
     tree.insert("/name\\::name", 1);
     tree.insert("/@:name", 2);
@@ -1177,9 +1175,9 @@ fn match_params() {
     assert_eq!(
         p.pieces,
         vec![
-            Piece::String(b"/name"),
-            Piece::String(b":"),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"name")), Kind::Normal),
+            Piece::String(b"/name".to_vec()),
+            Piece::String(b":".to_vec()),
+            Piece::Parameter(Position::Named(b"name".to_vec()), Kind::Normal),
         ]
     );
     assert_eq!(p.pattern(), "/name\\::name");
@@ -1190,8 +1188,8 @@ fn match_params() {
     assert_eq!(
         p.pieces,
         vec![
-            Piece::String(b"/@"),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"name")), Kind::Normal),
+            Piece::String(b"/@".to_vec()),
+            Piece::Parameter(Position::Named(b"name".to_vec()), Kind::Normal),
         ]
     );
     assert_eq!(p.pattern(), "/@:name");
@@ -1202,8 +1200,8 @@ fn match_params() {
     assert_eq!(
         p.pieces,
         vec![
-            Piece::String(b"/-"),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"name")), Kind::Normal),
+            Piece::String(b"/-".to_vec()),
+            Piece::Parameter(Position::Named(b"name".to_vec()), Kind::Normal),
         ]
     );
     assert_eq!(p.pattern(), "/-:name");
@@ -1214,8 +1212,8 @@ fn match_params() {
     assert_eq!(
         p.pieces,
         vec![
-            Piece::String(b"/."),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"name")), Kind::Normal),
+            Piece::String(b"/.".to_vec()),
+            Piece::Parameter(Position::Named(b"name".to_vec()), Kind::Normal),
         ]
     );
     assert_eq!(p.pattern(), "/.:name");
@@ -1226,8 +1224,8 @@ fn match_params() {
     assert_eq!(
         p.pieces,
         vec![
-            Piece::String(b"/~"),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"name")), Kind::Normal),
+            Piece::String(b"/~".to_vec()),
+            Piece::Parameter(Position::Named(b"name".to_vec()), Kind::Normal),
         ]
     );
     assert_eq!(p.pattern(), "/~:name");
@@ -1238,8 +1236,8 @@ fn match_params() {
     assert_eq!(
         p.pieces,
         vec![
-            Piece::String(b"/_"),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"name")), Kind::Normal),
+            Piece::String(b"/_".to_vec()),
+            Piece::Parameter(Position::Named(b"name".to_vec()), Kind::Normal),
         ]
     );
     assert_eq!(p.pattern(), "/_:name");
@@ -1250,8 +1248,8 @@ fn match_params() {
     assert_eq!(
         p.pieces,
         vec![
-            Piece::String(b"/"),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"name")), Kind::Normal),
+            Piece::String(b"/".to_vec()),
+            Piece::Parameter(Position::Named(b"name".to_vec()), Kind::Normal),
         ]
     );
     assert_eq!(p.pattern(), "/:name");
@@ -1262,7 +1260,7 @@ fn match_params() {
     //     └── :
     //         └── /abc/
     //             └── ** •0
-    let mut tree = PathTree::<'static, usize>::new();
+    let mut tree = PathTree::<usize>::new();
 
     tree.insert("/api/v1/:param/abc/*", 1);
 
@@ -1271,11 +1269,11 @@ fn match_params() {
     assert_eq!(
         p.pieces,
         vec![
-            Piece::String(b"/api/v1/"),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"param")), Kind::Normal),
-            Piece::String(b"/abc/"),
+            Piece::String(b"/api/v1/".to_vec()),
+            Piece::Parameter(Position::Named(b"param".to_vec()), Kind::Normal),
+            Piece::String(b"/abc/".to_vec()),
             Piece::Parameter(
-                Position::Index(1, Cow::Borrowed(b"*1")),
+                Position::Index(1, b"*1".to_vec()),
                 Kind::ZeroOrMoreSegment
             ),
         ]
@@ -1296,7 +1294,7 @@ fn match_params() {
     //             └── ??
     //                 └── /
     //                     └── ?? •0
-    let mut tree = PathTree::<'static, usize>::new();
+    let mut tree = PathTree::<usize>::new();
 
     tree.insert("/api/:day/:month?/:year?", 1);
 
@@ -1307,16 +1305,16 @@ fn match_params() {
     assert_eq!(
         p.pieces,
         vec![
-            Piece::String(b"/api/"),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"day")), Kind::Normal),
-            Piece::String(b"/"),
+            Piece::String(b"/api/".to_vec()),
+            Piece::Parameter(Position::Named(b"day".to_vec()), Kind::Normal),
+            Piece::String(b"/".to_vec()),
             Piece::Parameter(
-                Position::Named(Cow::Borrowed(b"month")),
+                Position::Named(b"month".to_vec()),
                 Kind::OptionalSegment
             ),
-            Piece::String(b"/"),
+            Piece::String(b"/".to_vec()),
             Piece::Parameter(
-                Position::Named(Cow::Borrowed(b"year")),
+                Position::Named(b"year".to_vec()),
                 Kind::OptionalSegment
             ),
         ]
@@ -1351,7 +1349,7 @@ fn match_params() {
     //             └── ?
     //                 └── .
     //                     └── ? •0
-    let mut tree = PathTree::<'static, usize>::new();
+    let mut tree = PathTree::<usize>::new();
 
     tree.insert("/api/:day.:month?.:year?", 1);
     tree.insert("/api/:day-:month?-:year?", 2);
@@ -1365,12 +1363,12 @@ fn match_params() {
     assert_eq!(
         p.pieces,
         vec![
-            Piece::String(b"/api/"),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"day")), Kind::Normal),
-            Piece::String(b"."),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"month")), Kind::Optional),
-            Piece::String(b"."),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"year")), Kind::Optional),
+            Piece::String(b"/api/".to_vec()),
+            Piece::Parameter(Position::Named(b"day".to_vec()), Kind::Normal),
+            Piece::String(b".".to_vec()),
+            Piece::Parameter(Position::Named(b"month".to_vec()), Kind::Optional),
+            Piece::String(b".".to_vec()),
+            Piece::Parameter(Position::Named(b"year".to_vec()), Kind::Optional),
         ]
     );
     assert_eq!(p.pattern(), "/api/:day.:month?.:year?");
@@ -1392,12 +1390,12 @@ fn match_params() {
     assert_eq!(
         p.pieces,
         vec![
-            Piece::String(b"/api/"),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"day")), Kind::Normal),
-            Piece::String(b"-"),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"month")), Kind::Optional),
-            Piece::String(b"-"),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"year")), Kind::Optional),
+            Piece::String(b"/api/".to_vec()),
+            Piece::Parameter(Position::Named(b"day".to_vec()), Kind::Normal),
+            Piece::String(b"-".to_vec()),
+            Piece::Parameter(Position::Named(b"month".to_vec()), Kind::Optional),
+            Piece::String(b"-".to_vec()),
+            Piece::Parameter(Position::Named(b"year".to_vec()), Kind::Optional),
         ]
     );
     assert_eq!(p.pattern(), "/api/:day-:month?-:year?");
@@ -1423,7 +1421,7 @@ fn match_params() {
     //     │   └── .json •1
     //     └── *
     //         └── .json •2
-    let mut tree = PathTree::<'static, usize>::new();
+    let mut tree = PathTree::<usize>::new();
 
     tree.insert("/config/abc.json", 1);
     tree.insert("/config/+.json", 2);
@@ -1431,7 +1429,7 @@ fn match_params() {
 
     let p = tree.find("/config/abc.json").unwrap();
     assert_eq!(p.value, &1);
-    assert_eq!(p.pieces, vec![Piece::String(b"/config/abc.json")]);
+    assert_eq!(p.pieces, vec![Piece::String(b"/config/abc.json".to_vec())]);
     assert_eq!(p.pattern(), "/config/abc.json");
     assert_eq!(p.params(), vec![]);
 
@@ -1440,9 +1438,9 @@ fn match_params() {
     assert_eq!(
         p.pieces,
         vec![
-            Piece::String(b"/config/"),
-            Piece::Parameter(Position::Index(1, Cow::Borrowed(b"+1")), Kind::OneOrMore),
-            Piece::String(b".json"),
+            Piece::String(b"/config/".to_vec()),
+            Piece::Parameter(Position::Index(1, b"+1".to_vec()), Kind::OneOrMore),
+            Piece::String(b".json".to_vec()),
         ]
     );
     assert_eq!(p.pattern(), "/config/+.json");
@@ -1465,9 +1463,9 @@ fn match_params() {
     assert_eq!(
         p.pieces,
         vec![
-            Piece::String(b"/config/"),
-            Piece::Parameter(Position::Index(1, Cow::Borrowed(b"*1")), Kind::ZeroOrMore),
-            Piece::String(b".json"),
+            Piece::String(b"/config/".to_vec()),
+            Piece::Parameter(Position::Index(1, b"*1".to_vec()), Kind::ZeroOrMore),
+            Piece::String(b".json".to_vec()),
         ]
     );
     assert_eq!(p.pattern(), "/config/*.json");
@@ -1478,7 +1476,7 @@ fn match_params() {
     //     └── **
     //         └── /
     //             └── ?? •0
-    let mut tree = PathTree::<'static, usize>::new();
+    let mut tree = PathTree::<usize>::new();
 
     tree.insert("/api/*/:param?", 1);
 
@@ -1487,14 +1485,14 @@ fn match_params() {
     assert_eq!(
         p.pieces,
         vec![
-            Piece::String(b"/api/"),
+            Piece::String(b"/api/".to_vec()),
             Piece::Parameter(
-                Position::Index(1, Cow::Borrowed(b"*1")),
+                Position::Index(1, b"*1".to_vec()),
                 Kind::ZeroOrMoreSegment
             ),
-            Piece::String(b"/"),
+            Piece::String(b"/".to_vec()),
             Piece::Parameter(
-                Position::Named(Cow::Borrowed(b"param")),
+                Position::Named(b"param".to_vec()),
                 Kind::OptionalSegment
             ),
         ]
@@ -1525,7 +1523,7 @@ fn match_params() {
     //     └── **
     //         └── /
     //             └── : •0
-    let mut tree = PathTree::<'static, usize>::new();
+    let mut tree = PathTree::<usize>::new();
 
     tree.insert("/api/*/:param", 1);
 
@@ -1534,13 +1532,13 @@ fn match_params() {
     assert_eq!(
         p.pieces,
         vec![
-            Piece::String(b"/api/"),
+            Piece::String(b"/api/".to_vec()),
             Piece::Parameter(
-                Position::Index(1, Cow::Borrowed(b"*1")),
+                Position::Index(1, b"*1".to_vec()),
                 Kind::ZeroOrMoreSegment
             ),
-            Piece::String(b"/"),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"param")), Kind::Normal),
+            Piece::String(b"/".to_vec()),
+            Piece::Parameter(Position::Named(b"param".to_vec()), Kind::Normal),
         ]
     );
     assert_eq!(p.pattern(), "/api/*/:param");
@@ -1563,7 +1561,7 @@ fn match_params() {
     //     └── +
     //         └── /
     //             └── : •0
-    let mut tree = PathTree::<'static, usize>::new();
+    let mut tree = PathTree::<usize>::new();
 
     tree.insert("/api/+/:param", 1);
 
@@ -1572,10 +1570,10 @@ fn match_params() {
     assert_eq!(
         p.pieces,
         vec![
-            Piece::String(b"/api/"),
-            Piece::Parameter(Position::Index(1, Cow::Borrowed(b"+1")), Kind::OneOrMore),
-            Piece::String(b"/"),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"param")), Kind::Normal),
+            Piece::String(b"/api/".to_vec()),
+            Piece::Parameter(Position::Index(1, b"+1".to_vec()), Kind::OneOrMore),
+            Piece::String(b"/".to_vec()),
+            Piece::Parameter(Position::Named(b"param".to_vec()), Kind::Normal),
         ]
     );
     assert_eq!(p.pattern(), "/api/+/:param");
@@ -1597,7 +1595,7 @@ fn match_params() {
     //             └── :
     //                 └── /
     //                     └── : •0
-    let mut tree = PathTree::<'static, usize>::new();
+    let mut tree = PathTree::<usize>::new();
 
     tree.insert("/api/*/:param/:param2", 1);
 
@@ -1606,15 +1604,15 @@ fn match_params() {
     assert_eq!(
         p.pieces,
         vec![
-            Piece::String(b"/api/"),
+            Piece::String(b"/api/".to_vec()),
             Piece::Parameter(
-                Position::Index(1, Cow::Borrowed(b"*1")),
+                Position::Index(1, b"*1".to_vec()),
                 Kind::ZeroOrMoreSegment
             ),
-            Piece::String(b"/"),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"param")), Kind::Normal),
-            Piece::String(b"/"),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"param2")), Kind::Normal),
+            Piece::String(b"/".to_vec()),
+            Piece::Parameter(Position::Named(b"param".to_vec()), Kind::Normal),
+            Piece::String(b"/".to_vec()),
+            Piece::Parameter(Position::Named(b"param2".to_vec()), Kind::Normal),
         ]
     );
     assert_eq!(p.pattern(), "/api/*/:param/:param2");
@@ -1662,7 +1660,7 @@ fn match_params() {
 
 #[test]
 fn basic() {
-    let mut tree = PathTree::<'static, usize>::new();
+    let mut tree = PathTree::<usize>::new();
 
     tree.insert("/", 0)
         .insert("/login", 1)
@@ -1815,7 +1813,7 @@ fn basic() {
 
 #[test]
 fn github_tree() {
-    let mut tree = PathTree::<'static, usize>::new();
+    let mut tree = PathTree::<usize>::new();
 
     tree.insert("/", 0);
     tree.insert("/api", 1);
@@ -2163,13 +2161,13 @@ fn github_tree() {
     assert_eq!(
         p.pieces,
         &vec![
-            Piece::String(b"/"),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"org")), Kind::Normal),
-            Piece::String(b"/"),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"repo")), Kind::Normal),
-            Piece::String(b"/releases/"),
+            Piece::String(b"/".to_vec()),
+            Piece::Parameter(Position::Named(b"org".to_vec()), Kind::Normal),
+            Piece::String(b"/".to_vec()),
+            Piece::Parameter(Position::Named(b"repo".to_vec()), Kind::Normal),
+            Piece::String(b"/releases/".to_vec()),
             Piece::Parameter(
-                Position::Index(1, Cow::Borrowed(b"*1")),
+                Position::Index(1, b"*1".to_vec()),
                 Kind::ZeroOrMoreSegment
             ),
         ]
@@ -2190,16 +2188,16 @@ fn github_tree() {
     assert_eq!(
         p.pieces,
         &vec![
-            Piece::String(b"/"),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"org")), Kind::Normal),
-            Piece::String(b"/"),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"repo")), Kind::Normal),
-            Piece::String(b"/releases/download/"),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"tag")), Kind::Normal),
-            Piece::String(b"/"),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"filename")), Kind::Normal),
-            Piece::String(b"."),
-            Piece::Parameter(Position::Named(Cow::Borrowed(b"ext")), Kind::Normal),
+            Piece::String(b"/".to_vec()),
+            Piece::Parameter(Position::Named(b"org".to_vec()), Kind::Normal),
+            Piece::String(b"/".to_vec()),
+            Piece::Parameter(Position::Named(b"repo".to_vec()), Kind::Normal),
+            Piece::String(b"/releases/download/".to_vec()),
+            Piece::Parameter(Position::Named(b"tag".to_vec()), Kind::Normal),
+            Piece::String(b"/".to_vec()),
+            Piece::Parameter(Position::Named(b"filename".to_vec()), Kind::Normal),
+            Piece::String(b".".to_vec()),
+            Piece::Parameter(Position::Named(b"ext".to_vec()), Kind::Normal),
         ]
     );
     assert_eq!(

--- a/tests/tree.rs
+++ b/tests/tree.rs
@@ -488,10 +488,7 @@ fn match_params() {
             Piece::String(b"/api/v1/".to_vec()),
             Piece::Parameter(Position::Named(b"param".to_vec()), Kind::Normal),
             Piece::String(b"/".to_vec()),
-            Piece::Parameter(
-                Position::Index(1, b"*1".to_vec()),
-                Kind::ZeroOrMoreSegment
-            ),
+            Piece::Parameter(Position::Index(1, b"*1".to_vec()), Kind::ZeroOrMoreSegment),
         ]
     );
 
@@ -547,10 +544,7 @@ fn match_params() {
         p.pieces,
         &vec![
             Piece::String(b"/api/v1/".to_vec()),
-            Piece::Parameter(
-                Position::Named(b"param".to_vec()),
-                Kind::OptionalSegment
-            ),
+            Piece::Parameter(Position::Named(b"param".to_vec()), Kind::OptionalSegment),
         ]
     );
 
@@ -1272,10 +1266,7 @@ fn match_params() {
             Piece::String(b"/api/v1/".to_vec()),
             Piece::Parameter(Position::Named(b"param".to_vec()), Kind::Normal),
             Piece::String(b"/abc/".to_vec()),
-            Piece::Parameter(
-                Position::Index(1, b"*1".to_vec()),
-                Kind::ZeroOrMoreSegment
-            ),
+            Piece::Parameter(Position::Index(1, b"*1".to_vec()), Kind::ZeroOrMoreSegment),
         ]
     );
     assert_eq!(p.pattern(), "/api/v1/:param/abc/*");
@@ -1308,15 +1299,9 @@ fn match_params() {
             Piece::String(b"/api/".to_vec()),
             Piece::Parameter(Position::Named(b"day".to_vec()), Kind::Normal),
             Piece::String(b"/".to_vec()),
-            Piece::Parameter(
-                Position::Named(b"month".to_vec()),
-                Kind::OptionalSegment
-            ),
+            Piece::Parameter(Position::Named(b"month".to_vec()), Kind::OptionalSegment),
             Piece::String(b"/".to_vec()),
-            Piece::Parameter(
-                Position::Named(b"year".to_vec()),
-                Kind::OptionalSegment
-            ),
+            Piece::Parameter(Position::Named(b"year".to_vec()), Kind::OptionalSegment),
         ]
     );
     assert_eq!(p.pattern(), "/api/:day/:month?/:year?");
@@ -1486,15 +1471,9 @@ fn match_params() {
         p.pieces,
         vec![
             Piece::String(b"/api/".to_vec()),
-            Piece::Parameter(
-                Position::Index(1, b"*1".to_vec()),
-                Kind::ZeroOrMoreSegment
-            ),
+            Piece::Parameter(Position::Index(1, b"*1".to_vec()), Kind::ZeroOrMoreSegment),
             Piece::String(b"/".to_vec()),
-            Piece::Parameter(
-                Position::Named(b"param".to_vec()),
-                Kind::OptionalSegment
-            ),
+            Piece::Parameter(Position::Named(b"param".to_vec()), Kind::OptionalSegment),
         ]
     );
     assert_eq!(p.pattern(), "/api/*/:param?");
@@ -1533,10 +1512,7 @@ fn match_params() {
         p.pieces,
         vec![
             Piece::String(b"/api/".to_vec()),
-            Piece::Parameter(
-                Position::Index(1, b"*1".to_vec()),
-                Kind::ZeroOrMoreSegment
-            ),
+            Piece::Parameter(Position::Index(1, b"*1".to_vec()), Kind::ZeroOrMoreSegment),
             Piece::String(b"/".to_vec()),
             Piece::Parameter(Position::Named(b"param".to_vec()), Kind::Normal),
         ]
@@ -1605,10 +1581,7 @@ fn match_params() {
         p.pieces,
         vec![
             Piece::String(b"/api/".to_vec()),
-            Piece::Parameter(
-                Position::Index(1, b"*1".to_vec()),
-                Kind::ZeroOrMoreSegment
-            ),
+            Piece::Parameter(Position::Index(1, b"*1".to_vec()), Kind::ZeroOrMoreSegment),
             Piece::String(b"/".to_vec()),
             Piece::Parameter(Position::Named(b"param".to_vec()), Kind::Normal),
             Piece::String(b"/".to_vec()),
@@ -2166,10 +2139,7 @@ fn github_tree() {
             Piece::String(b"/".to_vec()),
             Piece::Parameter(Position::Named(b"repo".to_vec()), Kind::Normal),
             Piece::String(b"/releases/".to_vec()),
-            Piece::Parameter(
-                Position::Index(1, b"*1".to_vec()),
-                Kind::ZeroOrMoreSegment
-            ),
+            Piece::Parameter(Position::Index(1, b"*1".to_vec()), Kind::ZeroOrMoreSegment),
         ]
     );
 


### PR DESCRIPTION
A mentioned in #18 the added lifetime would limit use of the API as well as cause issue with PyO3 bindings. This removes it using `Vec`s and `to_vec`s.

I do plan on using this commit as the basis for my optimization experiments which may be included depending on if this is merged or not.

Benchmark ([mimalloc](https://github.com/microsoft/mimalloc)):

<table>
<tr>
	<td>
	<td>matchit
	<td>path-tree
	<td>w/o lifetime
<tr>
	<td>insert
	<td>59µs
	<td>73µs
	<td>84µs
<tr>
	<td>find
	<td>45µs
	<td>40µs
	<td>40µs
</table>

Benchmark (Windows' allocator):

<table>
<tr>
	<td>
	<td>matchit
	<td>path-tree
	<td>w/o lifetime
<tr>
	<td>insert
	<td>109µs
	<td>128µs
	<td>158µs
<tr>
	<td>find
	<td>31µs
	<td>40µs
	<td>39µs
</table>