### PR TITLE
`no_std` support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,7 +142,12 @@ use alloc::{
     string::{String, ToString as _},
     vec::Vec,
 };
-use core::{iter, marker::PhantomData, slice, str::from_utf8};
+use core::{
+    iter::{Copied, FilterMap, Zip},
+    marker::PhantomData,
+    slice::Iter,
+    str::from_utf8,
+};
 
 use smallvec::SmallVec;
 
@@ -345,7 +350,7 @@ type FilterIter<'a> = FilterMap<Iter<'a, Piece>, fn(piece: &'a Piece) -> Option<
 
 /// A Parameters Iterator.
 pub struct ParamsIter<'p, 'a, 'b, T> {
-    iter: iter::Zip<FilterIter<'a>, iter::Copied<slice::Iter<'p, &'b str>>>,
+    iter: Zip<FilterIter<'a>, Copied<Iter<'p, &'b str>>>,
     _t: PhantomData<T>,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,10 +132,17 @@
 //! assert_eq!(r.params(), vec![("+1", "v1")]);
 //! ```
 
+#![no_std]
 #![forbid(unsafe_code)]
 #![warn(rust_2018_idioms, unreachable_pub)]
 
-use std::str::from_utf8;
+extern crate alloc;
+
+use alloc::{
+    string::{String, ToString as _},
+    vec::Vec,
+};
+use core::str::from_utf8;
 
 use smallvec::SmallVec;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -317,8 +317,7 @@ impl<'a, 'b, T> Path<'a, 'b, T> {
             match piece {
                 Piece::String(_) => None,
                 Piece::Parameter(p, _) => from_utf8(match p {
-                    Position::Index(_, n) => n,
-                    Position::Named(n) => n,
+                    Position::Index(_, n) | Position::Named(n) => n,
                 })
                 .ok(),
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,7 +142,7 @@ use alloc::{
     string::{String, ToString as _},
     vec::Vec,
 };
-use core::{marker::PhantomData, str::from_utf8, iter, slice};
+use core::{iter, marker::PhantomData, slice, str::from_utf8};
 
 use smallvec::SmallVec;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,7 +142,7 @@ use alloc::{
     string::{String, ToString as _},
     vec::Vec,
 };
-use core::str::from_utf8;
+use core::{marker::PhantomData, str::from_utf8, iter, slice};
 
 use smallvec::SmallVec;
 
@@ -339,7 +339,7 @@ type FilterIter<'a> =
     iter::FilterMap<slice::Iter<'a, Piece>, fn(piece: &'a Piece) -> Option<&'a str>>;
 
 pub struct ParamsIter<'p, 'a, 'b, T> {
-    iter: iter::Zip<FilterIter<'a>, std::iter::Copied<slice::Iter<'p, &'b str>>>,
+    iter: iter::Zip<FilterIter<'a>, iter::Copied<slice::Iter<'p, &'b str>>>,
     _t: PhantomData<T>,
 }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -55,7 +55,7 @@ impl<T: fmt::Debug> Node<T> {
                     if cursor < s.len() {
                         let (prefix, suffix) = s.split_at(cursor);
                         let mut node = Node::new(NodeKind::String(prefix.to_vec()), None);
-                        *p = suffix.to_vec();
+                        *s = suffix.to_vec();
                         ::core::mem::swap(self, &mut node);
                         self.nodes0.get_or_insert_with(Vec::new).push(node);
                     }

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,4 +1,5 @@
-use std::{
+use alloc::{format, string::String, vec::Vec};
+use core::{
     cmp::Ordering,
     fmt::{self, Write},
     ops::Range,
@@ -55,7 +56,7 @@ impl<T: fmt::Debug> Node<T> {
                         let (prefix, suffix) = p.split_at(cursor);
                         let mut node = Node::new(NodeKind::String(prefix.to_vec()), None);
                         *p = suffix.to_vec();
-                        ::std::mem::swap(self, &mut node);
+                        ::core::mem::swap(self, &mut node);
                         self.nodes0.get_or_insert_with(Vec::new).push(node);
                     }
                     if cursor != bytes.len() {

--- a/src/node.rs
+++ b/src/node.rs
@@ -80,7 +80,7 @@ impl<T: fmt::Debug> Node<T> {
                     // lets `/` at end
                     compare(s[0], bytes[0])
                 }
-                _ => unreachable!(),
+                NodeKind::Parameter(_) => unreachable!(),
             }) {
                 Ok(i) => nodes[i].insert_bytes(bytes),
                 Err(i) => {
@@ -98,7 +98,7 @@ impl<T: fmt::Debug> Node<T> {
         let i = nodes
             .binary_search_by(|node| match node.kind {
                 NodeKind::Parameter(pk) => pk.cmp(&kind),
-                _ => unreachable!(),
+                NodeKind::String(_) => unreachable!(),
             })
             .unwrap_or_else(|i| {
                 nodes.insert(i, Node::new(NodeKind::Parameter(kind), None));
@@ -150,7 +150,7 @@ impl<T: fmt::Debug> Node<T> {
                                         // lets `/` at end
                                         compare(s[0], bytes[0])
                                     }
-                                    _ => unreachable!(),
+                                    NodeKind::Parameter(_) => unreachable!(),
                                 })
                                 .ok()
                                 .and_then(|i| nodes[i]._find(start, bytes, ranges))
@@ -268,14 +268,14 @@ impl<T: fmt::Debug> Node<T> {
                     if m == 0 {
                         if k == &Kind::Normal {
                             return None;
-                        } else {
-                            // last
-                            if self.nodes0.is_none() && self.nodes1.is_none() {
-                                return self.value.as_ref().map(|id| {
-                                    ranges.push(start..start);
-                                    id
-                                });
-                            }
+                        }
+
+                        // last
+                        if self.nodes0.is_none() && self.nodes1.is_none() {
+                            return self.value.as_ref().map(|id| {
+                                ranges.push(start..start);
+                                id
+                            });
                         }
                     } else {
                         // static
@@ -289,7 +289,7 @@ impl<T: fmt::Debug> Node<T> {
                                         })
                                     })
                                 }
-                                _ => unreachable!(),
+                                NodeKind::Parameter(_) => unreachable!(),
                             })
                         }) {
                             return Some(id);
@@ -353,7 +353,7 @@ impl<T: fmt::Debug> Node<T> {
                                 .last()
                                 .filter(|node| match &node.kind {
                                     NodeKind::String(s) => s[0] == b'/',
-                                    _ => unreachable!(),
+                                    NodeKind::Parameter(_) => unreachable!(),
                                 })
                                 .and_then(|node| node._find(start, bytes, ranges))
                         }) {
@@ -367,14 +367,13 @@ impl<T: fmt::Debug> Node<T> {
                     if m == 0 {
                         if is_one_or_more {
                             return None;
-                        } else {
-                            // last
-                            if self.nodes0.is_none() && self.nodes1.is_none() {
-                                return self.value.as_ref().map(|id| {
-                                    ranges.push(start..start);
-                                    id
-                                });
-                            }
+                        }
+
+                        if self.nodes0.is_none() && self.nodes1.is_none() {
+                            return self.value.as_ref().map(|id| {
+                                ranges.push(start..start);
+                                id
+                            });
                         }
                     } else {
                         if self.nodes0.is_none() && self.nodes1.is_none() {
@@ -423,7 +422,7 @@ impl<T: fmt::Debug> Node<T> {
                                 .last()
                                 .filter(|node| match &node.kind {
                                     NodeKind::String(s) => s[0] == b'/',
-                                    _ => unreachable!(),
+                                    NodeKind::Parameter(_) => unreachable!(),
                                 })
                                 .and_then(|node| node._find(start, bytes, ranges))
                         }) {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -109,13 +109,11 @@ impl<'a> Parser<'a> {
                                 let prefix = if start >= 2 {
                                     self.input
                                         .get(start - 2..start - 1)
-                                        .map(|s| s == "/")
-                                        .unwrap_or(false)
+                                        .map_or(false, |s| s == "/")
                                 } else {
                                     false
                                 };
-                                let suffix =
-                                    self.cursor.peek().map(|(_, c)| *c == '/').unwrap_or(true);
+                                let suffix = self.cursor.peek().map_or(true, |(_, c)| *c == '/');
                                 prefix && suffix
                             };
                             if c == '?' {
@@ -168,12 +166,11 @@ impl<'a> Iterator for Parser<'a> {
                         } else {
                             let f = {
                                 let prefix = if i >= 1 {
-                                    self.input.get(i - 1..i).map(|s| s == "/").unwrap_or(false)
+                                    self.input.get(i - 1..i).map_or(false, |s| s == "/")
                                 } else {
                                     false
                                 };
-                                let suffix =
-                                    self.cursor.peek().map(|(_, c)| *c == '/').unwrap_or(true);
+                                let suffix = self.cursor.peek().map_or(true, |(_, c)| *c == '/');
                                 prefix && suffix
                             };
                             if f {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -162,10 +162,7 @@ impl<'a> Iterator for Parser<'a> {
                     self.count += 1;
                     self.pos = i + 1;
                     Some(Piece::Parameter(
-                        Position::Index(
-                            self.count,
-                            format!("{}{}", c, self.count).into_bytes(),
-                        ),
+                        Position::Index(self.count, format!("{}{}", c, self.count).into_bytes()),
                         if c == '+' {
                             Kind::OneOrMore
                         } else {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,4 +1,5 @@
-use std::{iter::Peekable, str::CharIndices};
+use alloc::{format, vec::Vec};
+use core::{iter::Peekable, str::CharIndices};
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Kind {
@@ -163,7 +164,7 @@ impl<'a> Iterator for Parser<'a> {
                     Some(Piece::Parameter(
                         Position::Index(
                             self.count,
-                            format!("{}{}", c, self.count).as_bytes().to_owned(),
+                            format!("{}{}", c, self.count).into_bytes(),
                         ),
                         if c == '+' {
                             Kind::OneOrMore


### PR DESCRIPTION
Here's basic support for `no_std` using the `alloc` crate as well as some code cleanup from Clippy lints that I did while attempting to remove `format!` calls.

`alloc::fmt` is pretty heavy module that I wanted to remove to shrink compile size and the best way I found was to use `String::push_str`. Sadly it caused longer `PathTree:insert` times so I left it out.

I don't actually develop in `no_std` environments but this is based off other crates and it all compiles and tests fine on my end. If anyone does use `no_std` left me know if this works.

Fixes #11