### PR TITLE
feat: extend api with iterator for routes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,7 +142,7 @@ use alloc::{
     string::{String, ToString},
     vec::Vec,
 };
-use core::str::from_utf8;
+use core::{slice::Iter, str::from_utf8};
 use smallvec::SmallVec;
 
 mod node;
@@ -257,6 +257,10 @@ impl<T> PathTree<T> {
 
             from_utf8(&bytes).map(ToString::to_string).ok()
         })
+    }
+
+    pub fn iter(&self) -> Iter<'_, (T, Vec<Piece>)> {
+        self.routes.iter()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -262,8 +262,13 @@ impl<T> PathTree<T> {
     pub fn iter(&self) -> Iter<'_, (T, Vec<Piece>)> {
         self.routes.iter()
     }
+}
 
-    pub fn into_iter(self) -> IntoIter<(T, Vec<Piece>)> {
+impl<T> IntoIterator for PathTree<T> {
+    type Item = (T, Vec<Piece>);
+    type IntoIter = IntoIter<(T, Vec<Piece>)>;
+
+    fn into_iter(self) -> Self::IntoIter {
         self.routes.into_iter()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,7 +140,7 @@ extern crate alloc;
 
 use alloc::{
     string::{String, ToString},
-    vec::Vec,
+    vec::{IntoIter, Vec},
 };
 use core::{slice::Iter, str::from_utf8};
 use smallvec::SmallVec;
@@ -261,6 +261,10 @@ impl<T> PathTree<T> {
 
     pub fn iter(&self) -> Iter<'_, (T, Vec<Piece>)> {
         self.routes.iter()
+    }
+
+    pub fn into_iter(self) -> IntoIter<(T, Vec<Piece>)> {
+        self.routes.into_iter()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,7 +140,7 @@ extern crate alloc;
 
 use alloc::{
     string::{String, ToString},
-    vec::{IntoIter, Vec},
+    vec::Vec,
 };
 use core::{slice::Iter, str::from_utf8};
 use smallvec::SmallVec;
@@ -264,12 +264,12 @@ impl<T> PathTree<T> {
     }
 }
 
-impl<T> IntoIterator for PathTree<T> {
-    type Item = (T, Vec<Piece>);
-    type IntoIter = IntoIter<(T, Vec<Piece>)>;
+impl<'a, T> IntoIterator for &'a PathTree<T> {
+    type Item = &'a (T, Vec<Piece>);
+    type IntoIter = Iter<'a, (T, Vec<Piece>)>;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.routes.into_iter()
+        self.iter()
     }
 }
 


### PR DESCRIPTION
Forward iterator access to the routes to allow collecting them as a client. This allows eg. collecting the routes to subscribe them when using the router in an MQTT usecase.